### PR TITLE
docs: document MCP subpackage install step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Or add as a git submodule into any project's `.claude/` directory.
 Expose the skills and audit tool to any MCP-compatible client.
 
 ```bash
-# From a git clone of this repo
+# Install the MCP subpackage deps once (root bun install does not cover it,
+# because the SDK is a devDependency kept out of the published bundle).
+cd packages/hig-doctor/src-mcp && bun install
+
+# Run from anywhere in the repo:
 bun packages/hig-doctor/src-mcp/src/index.ts
 ```
 


### PR DESCRIPTION
## Summary

A fresh `git clone` followed by the README's one-liner (`bun packages/hig-doctor/src-mcp/src/index.ts`) fails with:

```
error: Cannot find module '@modelcontextprotocol/sdk/server/index.js' from '.../src-mcp/src/index.ts'
```

The root `package.json` has no `workspaces` field, so `bun install` at the repo root doesn't resolve the MCP subpackage's `devDependencies` (including `@modelcontextprotocol/sdk`).

The fix here is documentation-only: surface the `cd packages/hig-doctor/src-mcp && bun install` step that `CONTRIBUTING.md` already mentions, in the user-facing MCP server section.

## Why not add `"workspaces"` to the root `package.json`?

I considered that, but `a85c287 fix: keep mcp package runtime-dependency free` intentionally moved `@modelcontextprotocol/sdk` from `dependencies` to `devDependencies` so the published `hig-mcp` bundle stays zero-runtime-dep (esbuild bundles the SDK into `dist/index.js`). Adding workspaces would either force npm consumers to install `@modelcontextprotocol/sdk` at install time, or break the existing publish flow.

The subpackage layout is correct as-is — it just needs a one-line README note.

## Test plan

- [ ] `git clone https://github.com/raintree-technology/hig-doctor.git && cd hig-doctor`
- [ ] Without this fix: `bun packages/hig-doctor/src-mcp/src/index.ts` fails with module-not-found.
- [ ] With this fix: the README now tells the reader to run `cd packages/hig-doctor/src-mcp && bun install` first, then `bun packages/hig-doctor/src-mcp/src/index.ts` starts the MCP server.
- [ ] Smoke-tested locally: server responds to MCP `initialize` and `tools/call hig_list_skills` correctly after the documented install.

## Diff

```diff
 ## MCP server
 
 Expose the skills and audit tool to any MCP-compatible client.
 
 ```bash
-# From a git clone of this repo
+# Install the MCP subpackage deps once (root bun install does not cover it,
+# because the SDK is a devDependency kept out of the published bundle).
+cd packages/hig-doctor/src-mcp && bun install
+
+# Run from anywhere in the repo:
 bun packages/hig-doctor/src-mcp/src/index.ts
 ```

Made with [Cursor](https://cursor.com)