### PR TITLE
feat: redesign topics browser with search, TOC, and agent markdown actions

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -190,6 +190,12 @@ html {
   z-index: -1;
 }
 
+/* Custom clear buttons handle this; the native control doubles them up */
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 code {
   font-family:
     "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, monospace;
@@ -225,6 +231,14 @@ body {
 
 .prose-hig > *:first-child {
   margin-top: 0;
+}
+
+/* Keep anchored headings clear of the fixed header */
+.prose-hig h1,
+.prose-hig h2,
+.prose-hig h3,
+.prose-hig h4 {
+  scroll-margin-top: 5.5rem;
 }
 
 .prose-hig h1 {

--- a/website/app/mcp/page.tsx
+++ b/website/app/mcp/page.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2, ChevronRight, Terminal } from "lucide-react";
 import type { Metadata } from "next";
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
+import McpCodeBlock from "@/components/McpCodeBlock";
 import { Separator } from "@/components/ui/separator";
 
 const BASE_URL = "https://apple.raintree.technology";
@@ -93,14 +94,6 @@ const jsonLd = {
   ],
 };
 
-function CodeBlock({ children }: { children: string }) {
-  return (
-    <pre className="overflow-x-auto rounded-xl border bg-[#1d1d1f] px-4 py-3.5 text-sm leading-7 text-white/85">
-      <code>{children}</code>
-    </pre>
-  );
-}
-
 export default function McpPage() {
   return (
     <div className="photo-bg min-h-screen">
@@ -124,7 +117,7 @@ export default function McpPage() {
 
           <section className="max-w-3xl">
             <p className="mb-4 text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
-              Submission-ready technical surface
+              MCP server · Audit CLI
             </p>
             <h1 className="text-4xl font-semibold tracking-tight sm:text-6xl">
               Apple HIG lookup and audits for MCP-compatible agents.
@@ -134,6 +127,16 @@ export default function McpPage() {
               the Model Context Protocol and ships a CLI that scans native and
               web UI code for accessibility, layout, color, typography, motion,
               control, and platform-pattern issues.
+            </p>
+            <p className="mt-4 text-sm text-muted-foreground">
+              The same reference content the tools serve is browsable at{" "}
+              <a
+                href="/topics"
+                className="text-foreground underline underline-offset-4 hover:opacity-70 transition-opacity"
+              >
+                /topics
+              </a>
+              , with per-topic Markdown for agents.
             </p>
           </section>
 
@@ -175,18 +178,18 @@ export default function McpPage() {
                     <Terminal className="h-4 w-4" aria-hidden="true" />
                     Run the audit CLI
                   </div>
-                  <CodeBlock>{"npx hig-doctor . --export"}</CodeBlock>
+                  <McpCodeBlock>{"npx hig-doctor . --export"}</McpCodeBlock>
                 </div>
                 <div>
                   <div className="mb-2 flex items-center gap-2 text-sm font-medium">
                     <Terminal className="h-4 w-4" aria-hidden="true" />
                     Run the MCP server from source
                   </div>
-                  <CodeBlock>
+                  <McpCodeBlock>
                     {
                       "git clone https://github.com/raintree-technology/hig-doctor.git\ncd hig-doctor/packages/hig-doctor/src-mcp\nbun install\nbun src/index.ts"
                     }
-                  </CodeBlock>
+                  </McpCodeBlock>
                 </div>
               </div>
             </section>

--- a/website/app/topics/[slug]/page.tsx
+++ b/website/app/topics/[slug]/page.tsx
@@ -1,14 +1,21 @@
-import { ChevronRight } from "lucide-react";
+import { ArrowLeft, ArrowRight, ChevronRight } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
+import TopicActions from "@/components/TopicActions";
 import TopicContent from "@/components/TopicContent";
 import TopicCTA from "@/components/TopicCTA";
 import TopicSidebar from "@/components/TopicSidebar";
+import TopicToc from "@/components/TopicToc";
 import { Separator } from "@/components/ui/separator";
-import { renderMarkdown } from "@/lib/markdown";
-import { getAllTopicSlugs, getTopicBySlug } from "@/lib/topics";
+import { extractH2Outline, renderMarkdown } from "@/lib/markdown";
+import {
+  getAllTopicSlugs,
+  getTopicBySlug,
+  splitAttribution,
+} from "@/lib/topics";
+import { anchorFor } from "@/lib/utils";
 
 const BASE_URL = "https://apple.raintree.technology";
 
@@ -59,7 +66,9 @@ export default async function TopicPage({
   const topic = getTopicBySlug(slug);
   if (!topic) notFound();
 
-  const html = await renderMarkdown(topic.content);
+  const { body, snapshotDate } = splitAttribution(topic.content);
+  const html = await renderMarkdown(body);
+  const toc = extractH2Outline(html);
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -137,28 +146,114 @@ export default async function TopicPage({
             <span className="text-foreground">{topic.title}</span>
           </nav>
 
-          {/* Title + metadata */}
+          {/* Title + actions */}
           <div className="mb-10">
-            <h1 className="text-4xl sm:text-5xl font-semibold tracking-tight mb-4">
+            <h1 className="text-4xl sm:text-5xl font-semibold tracking-tight mb-5">
               {topic.title}
             </h1>
-            <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-              <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1">
-                {topic.categoryName}
-              </span>
-              <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <a
+                href={`/topics#${anchorFor(topic.categoryName)}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-muted/40 px-3.5 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-colors"
+              >
                 {topic.skillDisplayName}
-              </span>
+                {topic.categoryName !== topic.skillDisplayName && (
+                  <span className="text-muted-foreground/60">
+                    · {topic.categoryName}
+                  </span>
+                )}
+              </a>
+              <TopicActions slug={slug} />
             </div>
           </div>
 
           {/* Two-column layout */}
           <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-12 pb-16">
-            <TopicContent html={html} />
+            <div className="min-w-0">
+              <TopicToc
+                items={toc}
+                variant="collapsible"
+                className="lg:hidden mb-8"
+              />
+              <TopicContent html={html} />
+
+              {/* Attribution — same facts as the source block, as small print */}
+              <p className="mt-10 border-t border-border/50 pt-5 text-[13px] leading-relaxed text-muted-foreground/80">
+                Apple HIG text and imagery are © Apple Inc. This page is a
+                structured index of Apple’s canonical documentation
+                {snapshotDate ? ` (snapshot ${snapshotDate})` : ""}, provided
+                for quick reference and AI-agent consumption — it isn’t
+                affiliated with or endorsed by Apple.
+                {topic.source ? (
+                  <>
+                    {" "}
+                    Read the original at{" "}
+                    <a
+                      href={topic.source}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline underline-offset-4 hover:text-foreground transition-colors"
+                    >
+                      developer.apple.com
+                      <span className="sr-only"> (opens in new tab)</span>
+                    </a>
+                    .
+                  </>
+                ) : null}
+              </p>
+
+              {/* Sequential navigation within the skill */}
+              {(topic.prevTopic || topic.nextTopic) && (
+                <nav
+                  aria-label={`More ${topic.skillDisplayName} topics`}
+                  className="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-4"
+                >
+                  {topic.prevTopic ? (
+                    <a
+                      href={`/topics/${topic.prevTopic.slug}`}
+                      className="group rounded-xl glass p-5 transition-colors hover:border-foreground/20"
+                    >
+                      <span className="flex items-center gap-1.5 text-xs uppercase tracking-wider text-muted-foreground mb-1.5">
+                        <ArrowLeft
+                          className="h-3 w-3 transition-transform group-hover:-translate-x-0.5"
+                          aria-hidden="true"
+                        />
+                        Previous in {topic.skillDisplayName}
+                      </span>
+                      <span className="text-sm font-medium text-foreground">
+                        {topic.prevTopic.title}
+                      </span>
+                    </a>
+                  ) : (
+                    <span className="hidden sm:block" aria-hidden="true" />
+                  )}
+                  {topic.nextTopic && (
+                    <a
+                      href={`/topics/${topic.nextTopic.slug}`}
+                      className="group rounded-xl glass p-5 text-right transition-colors hover:border-foreground/20"
+                    >
+                      <span className="flex items-center justify-end gap-1.5 text-xs uppercase tracking-wider text-muted-foreground mb-1.5">
+                        Next in {topic.skillDisplayName}
+                        <ArrowRight
+                          className="h-3 w-3 transition-transform group-hover:translate-x-0.5"
+                          aria-hidden="true"
+                        />
+                      </span>
+                      <span className="text-sm font-medium text-foreground">
+                        {topic.nextTopic.title}
+                      </span>
+                    </a>
+                  )}
+                </nav>
+              )}
+            </div>
+
             <TopicSidebar
               skillDisplayName={topic.skillDisplayName}
               categoryName={topic.categoryName}
               source={topic.source}
+              snapshotDate={snapshotDate}
+              toc={toc}
               relatedTopics={topic.relatedTopics}
             />
           </div>

--- a/website/app/topics/page.tsx
+++ b/website/app/topics/page.tsx
@@ -1,11 +1,15 @@
-import { ChevronRight, FileText } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import type { Metadata } from "next";
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
 import TopicCTA from "@/components/TopicCTA";
+import TopicsExplorer, {
+  type ExplorerCategory,
+} from "@/components/TopicsExplorer";
 import { Separator } from "@/components/ui/separator";
 import { categories } from "@/lib/skills-data";
 import { getAllTopicMetas } from "@/lib/topics";
+import { anchorFor } from "@/lib/utils";
 
 const BASE_URL = "https://apple.raintree.technology";
 
@@ -29,17 +33,9 @@ export const metadata: Metadata = {
 export default function TopicsIndex() {
   const allMetas = getAllTopicMetas();
 
-  // Group by category -> skill
-  const grouped: {
-    categoryName: string;
-    skills: {
-      skillDisplayName: string;
-      topics: { slug: string; title: string }[];
-    }[];
-  }[] = [];
-
+  const grouped: ExplorerCategory[] = [];
   for (const cat of categories) {
-    const skills: (typeof grouped)[0]["skills"] = [];
+    const skills: ExplorerCategory["skills"] = [];
     for (const skill of cat.skills) {
       const topics = allMetas
         .filter((m) => m.skillName === skill.name)
@@ -49,7 +45,11 @@ export default function TopicsIndex() {
       }
     }
     if (skills.length > 0) {
-      grouped.push({ categoryName: cat.name, skills });
+      grouped.push({
+        categoryName: cat.name,
+        anchor: anchorFor(cat.name),
+        skills,
+      });
     }
   }
 
@@ -109,49 +109,17 @@ export default function TopicsIndex() {
             <span className="text-foreground">Topics</span>
           </nav>
 
-          <div className="text-center mb-14">
+          <div className="text-center mb-10">
             <h1 className="text-4xl sm:text-5xl font-semibold tracking-tight mb-4">
               Apple HIG Topics
             </h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              Browse all {allMetas.length} Apple Human Interface Guidelines
-              topics, organized by category.
+              Every Apple Human Interface Guidelines topic in HIG Doctor —
+              search it, or jump to a category.
             </p>
           </div>
 
-          <div className="space-y-12 pb-16">
-            {grouped.map((cat) => (
-              <section key={cat.categoryName}>
-                <h2 className="text-2xl font-semibold tracking-tight mb-6">
-                  {cat.categoryName}
-                </h2>
-                <div className="space-y-6">
-                  {cat.skills.map((skill) => (
-                    <div key={skill.skillDisplayName}>
-                      <h3 className="text-sm uppercase tracking-wider text-muted-foreground mb-3">
-                        {skill.skillDisplayName}
-                      </h3>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2">
-                        {skill.topics.map((topic) => (
-                          <a
-                            key={topic.slug}
-                            href={`/topics/${topic.slug}`}
-                            className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-                          >
-                            <FileText
-                              className="h-3.5 w-3.5 shrink-0 opacity-50"
-                              aria-hidden="true"
-                            />
-                            {topic.title}
-                          </a>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </section>
-            ))}
-          </div>
+          <TopicsExplorer categories={grouped} totalTopics={allMetas.length} />
         </div>
 
         <div className="mx-auto max-w-6xl px-6">

--- a/website/components/FAQ.tsx
+++ b/website/components/FAQ.tsx
@@ -6,6 +6,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { totalReferences, totalSkills } from "@/lib/skills-data";
 
 const questions = [
   {
@@ -22,7 +23,7 @@ const questions = [
   },
   {
     q: "What platforms and topics does this cover?",
-    a: "All five Apple platforms — iOS, iPadOS, macOS, watchOS, and visionOS. Covers foundations (color, typography, layout), every component category (navigation, menus, controls, dialogs), input methods, UX patterns, and Apple technology integrations like Apple Pay, Siri, and HealthKit. 14 skills, 100+ reference topics.",
+    a: `All five Apple platforms — iOS, iPadOS, macOS, watchOS, and visionOS. Covers foundations (color, typography, layout), every component category (navigation, menus, controls, dialogs), input methods, UX patterns, and Apple technology integrations like Apple Pay, Siri, and HealthKit. ${totalSkills} skills, ${totalReferences} reference topics.`,
   },
   {
     q: "How do I keep it up to date when Apple changes the HIG?",

--- a/website/components/Header.tsx
+++ b/website/components/Header.tsx
@@ -1,22 +1,33 @@
 "use client";
 
 import { Github, Menu, X } from "lucide-react";
+import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import BrandMark from "@/components/BrandMark";
 import { cn } from "@/lib/utils";
 
-const homeNavItems = [
+interface NavItem {
+  label: string;
+  href: string;
+  /** Section id for the home-page scrollspy */
+  id?: string;
+  /** Route prefix that marks this item active on subpages */
+  route?: string;
+}
+
+const homeNavItems: NavItem[] = [
   { label: "Use Cases", href: "#use-cases", id: "use-cases" },
   { label: "How It Works", href: "#how-it-works", id: "how-it-works" },
   { label: "What's Included", href: "#skills", id: "skills" },
-  { label: "MCP", href: "/mcp", id: "mcp" },
+  { label: "Topics", href: "/topics", route: "/topics" },
+  { label: "MCP", href: "/mcp", route: "/mcp" },
   { label: "Install", href: "#install", id: "install" },
   { label: "FAQ", href: "#faq", id: "faq" },
 ];
 
-const topicNavItems = [
-  { label: "Topics", href: "/topics" },
-  { label: "MCP", href: "/mcp" },
+const topicNavItems: NavItem[] = [
+  { label: "Topics", href: "/topics", route: "/topics" },
+  { label: "MCP", href: "/mcp", route: "/mcp" },
   { label: "Install", href: "/#install" },
 ];
 
@@ -29,6 +40,7 @@ export default function Header({
   const [menuOpen, setMenuOpen] = useState(false);
   const [activeSection, setActiveSection] = useState<string | null>(null);
   const headerRef = useRef<HTMLElement>(null);
+  const pathname = usePathname();
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
@@ -44,6 +56,7 @@ export default function Header({
         const offset = 100;
         let current: string | null = null;
         for (const item of homeNavItems) {
+          if (!item.id) continue;
           const el = document.getElementById(item.id);
           if (el) {
             const top = el.getBoundingClientRect().top;
@@ -88,6 +101,11 @@ export default function Header({
 
   const navItems = variant === "home" ? homeNavItems : topicNavItems;
 
+  const isItemActive = (item: NavItem) => {
+    if (item.route && pathname?.startsWith(item.route)) return true;
+    return variant === "home" && !!item.id && activeSection === item.id;
+  };
+
   return (
     <header
       ref={headerRef}
@@ -111,12 +129,9 @@ export default function Header({
           HIG Doctor
         </a>
 
-        <div className="hidden md:flex items-center gap-8">
+        <div className="hidden md:flex items-center gap-6">
           {navItems.map((item) => {
-            const isActive =
-              variant === "home" &&
-              "id" in item &&
-              activeSection === (item as (typeof homeNavItems)[0]).id;
+            const isActive = isItemActive(item);
             return (
               <a
                 key={item.label}
@@ -127,7 +142,13 @@ export default function Header({
                     ? "text-foreground bg-accent"
                     : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
                 )}
-                aria-current={isActive ? "true" : undefined}
+                aria-current={
+                  item.route && pathname?.startsWith(item.route)
+                    ? "page"
+                    : isActive
+                      ? "true"
+                      : undefined
+                }
               >
                 {item.label}
               </a>
@@ -170,33 +191,38 @@ export default function Header({
         aria-hidden={!menuOpen}
       >
         <div className="min-h-0">
-          <div className="border-t border-border/50 bg-background/80 backdrop-blur-xl px-6 py-3">
-            <div className="flex flex-col gap-1" role="menu">
+          <nav
+            aria-label="Mobile"
+            className="border-t border-border/50 bg-background/80 backdrop-blur-xl px-6 py-3"
+          >
+            <ul className="flex flex-col gap-1 list-none p-0">
               {navItems.map((item) => {
-                const isActive =
-                  variant === "home" &&
-                  "id" in item &&
-                  activeSection === (item as (typeof homeNavItems)[0]).id;
+                const isActive = isItemActive(item);
                 return (
-                  <a
-                    key={item.label}
-                    href={item.href}
-                    onClick={closeMenu}
-                    role="menuitem"
-                    tabIndex={menuOpen ? 0 : -1}
-                    className={cn(
-                      "text-sm transition-colors py-2",
-                      isActive
-                        ? "text-foreground"
-                        : "text-muted-foreground hover:text-foreground",
-                    )}
-                  >
-                    {item.label}
-                  </a>
+                  <li key={item.label}>
+                    <a
+                      href={item.href}
+                      onClick={closeMenu}
+                      tabIndex={menuOpen ? 0 : -1}
+                      aria-current={
+                        item.route && pathname?.startsWith(item.route)
+                          ? "page"
+                          : undefined
+                      }
+                      className={cn(
+                        "block text-sm transition-colors py-2",
+                        isActive
+                          ? "text-foreground"
+                          : "text-muted-foreground hover:text-foreground",
+                      )}
+                    >
+                      {item.label}
+                    </a>
+                  </li>
                 );
               })}
-            </div>
-          </div>
+            </ul>
+          </nav>
         </div>
       </div>
     </header>

--- a/website/components/McpCodeBlock.tsx
+++ b/website/components/McpCodeBlock.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { CopyStatus, useCopyToClipboard } from "@/lib/useCopyToClipboard";
+
+/** Code block with a copy affordance, matching the Install section's pattern. */
+export default function McpCodeBlock({ children }: { children: string }) {
+  const { copied, copy } = useCopyToClipboard();
+  const isCopied = copied !== null;
+
+  return (
+    <div className="relative group">
+      <pre className="overflow-x-auto rounded-xl border bg-[#1d1d1f] px-4 py-3.5 pr-12 text-sm leading-7 text-white/85">
+        <code>{children}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={() => copy(children)}
+        className="absolute right-2 top-2 p-2 rounded-md text-white/50 hover:text-white hover:bg-white/10 transition-all"
+        aria-label="Copy command"
+      >
+        {isCopied ? (
+          <Check className="h-4 w-4 text-green-500" />
+        ) : (
+          <Copy className="h-4 w-4" />
+        )}
+      </button>
+      <CopyStatus active={isCopied} />
+    </div>
+  );
+}

--- a/website/components/Skills.tsx
+++ b/website/components/Skills.tsx
@@ -246,6 +246,16 @@ export default function Skills() {
             </Table>
           </div>
         </div>
+
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          Prefer reading in the browser?{" "}
+          <a
+            href="/topics"
+            className="text-foreground underline underline-offset-4 hover:opacity-70 transition-opacity"
+          >
+            Browse all {totalReferences} HIG topics
+          </a>
+        </p>
       </div>
     </section>
   );

--- a/website/components/TopicActions.tsx
+++ b/website/components/TopicActions.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Check, Copy, FileCode2 } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Agent-oriented actions for a topic: copy the canonical markdown (served by
+ * /raw/[slug]) or open it directly. Copying fetches the same text an agent
+ * would retrieve, including source attribution.
+ */
+export default function TopicActions({ slug }: { slug: string }) {
+  const [state, setState] = useState<"idle" | "copied" | "error">("idle");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = useCallback(async () => {
+    const getText = async () => {
+      const res = await fetch(`/raw/${slug}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.text();
+    };
+    try {
+      if (typeof ClipboardItem !== "undefined" && navigator.clipboard.write) {
+        // Promise-backed ClipboardItem keeps the user-gesture activation alive
+        // across the fetch — required for Safari, where fetch-then-writeText
+        // fails once the gesture expires.
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            "text/plain": getText().then(
+              (t) => new Blob([t], { type: "text/plain" }),
+            ),
+          }),
+        ]);
+      } else {
+        await navigator.clipboard.writeText(await getText());
+      }
+      setState("copied");
+    } catch {
+      setState("error");
+    }
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setState("idle"), 2500);
+  }, [slug]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-muted/40 px-3.5 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-colors"
+      >
+        {state === "copied" ? (
+          <Check className="h-3.5 w-3.5 text-green-500" aria-hidden="true" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+        {state === "copied" ? "Copied for your agent" : "Copy as Markdown"}
+      </button>
+      <a
+        href={`/raw/${slug}`}
+        className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-muted/40 px-3.5 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-colors"
+      >
+        <FileCode2 className="h-3.5 w-3.5" aria-hidden="true" />
+        View as Markdown
+      </a>
+      <span aria-live="polite" className="sr-only">
+        {state === "copied" ? "Markdown copied to clipboard" : ""}
+        {state === "error" ? "Copy failed" : ""}
+      </span>
+      {state === "error" && (
+        <span className="text-sm text-red-400">
+          Couldn’t copy — open the Markdown view instead.
+        </span>
+      )}
+    </div>
+  );
+}

--- a/website/components/TopicSidebar.tsx
+++ b/website/components/TopicSidebar.tsx
@@ -1,6 +1,9 @@
-import { ArrowRight, ExternalLink, FileText } from "lucide-react";
+import { ArrowRight, ExternalLink } from "lucide-react";
+import type { TocEntry } from "@/lib/markdown";
 import type { TopicMeta } from "@/lib/topics";
+import { anchorFor } from "@/lib/utils";
 import TopicCopyButton from "./TopicCopyButton";
+import TopicToc from "./TopicToc";
 
 const INSTALL_COMMAND = "npx skills add raintree-technology/hig-doctor";
 
@@ -8,51 +11,87 @@ interface TopicSidebarProps {
   skillDisplayName: string;
   categoryName: string;
   source: string;
+  snapshotDate: string | null;
+  toc: TocEntry[];
   relatedTopics: TopicMeta[];
+}
+
+function formatSnapshot(date: string): string {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return date;
+  return parsed.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    timeZone: "UTC",
+  });
 }
 
 export default function TopicSidebar({
   skillDisplayName,
   categoryName,
   source,
+  snapshotDate,
+  toc,
   relatedTopics,
 }: TopicSidebarProps) {
-  return (
-    <aside className="space-y-6 lg:sticky lg:top-24">
-      {/* Skill info */}
-      <div className="rounded-xl glass p-6">
-        <p className="text-[13px] uppercase tracking-wider text-muted-foreground mb-2">
-          Skill
-        </p>
-        <a
-          href="/#skills"
-          className="inline-flex items-center gap-2 text-sm font-medium text-foreground hover:opacity-70 transition-opacity"
-        >
-          <FileText
-            className="h-4 w-4 text-muted-foreground"
-            aria-hidden="true"
-          />
-          {skillDisplayName}
-          <span className="text-muted-foreground font-normal">
-            {categoryName}
-          </span>
-        </a>
-      </div>
+  const showCategory = categoryName !== skillDisplayName;
 
-      {/* Apple Developer link */}
-      {source && (
-        <div className="rounded-xl glass p-6">
+  return (
+    <aside className="space-y-6 lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto">
+      {/* On this page — the collapsible variant above the article covers small screens */}
+      {toc.length >= 2 && (
+        <div className="hidden lg:block rounded-xl glass p-6">
+          <TopicToc items={toc} />
+        </div>
+      )}
+
+      {/* About this reference */}
+      <div className="rounded-xl glass p-6">
+        <p className="text-[13px] uppercase tracking-wider text-muted-foreground mb-3">
+          About this reference
+        </p>
+        <dl className="space-y-2.5 text-sm">
+          <div className="flex items-baseline justify-between gap-3">
+            <dt className="text-muted-foreground shrink-0">Skill</dt>
+            <dd className="text-right">
+              <a
+                href={`/topics#${anchorFor(categoryName)}`}
+                className="font-medium text-foreground hover:opacity-70 transition-opacity"
+              >
+                {skillDisplayName}
+              </a>
+            </dd>
+          </div>
+          {showCategory && (
+            <div className="flex items-baseline justify-between gap-3">
+              <dt className="text-muted-foreground shrink-0">Category</dt>
+              <dd className="text-foreground text-right">{categoryName}</dd>
+            </div>
+          )}
+          {snapshotDate && (
+            <div className="flex items-baseline justify-between gap-3">
+              <dt className="text-muted-foreground shrink-0">HIG snapshot</dt>
+              <dd className="text-foreground text-right">
+                <time dateTime={snapshotDate}>
+                  {formatSnapshot(snapshotDate)}
+                </time>
+              </dd>
+            </div>
+          )}
+        </dl>
+        {source && (
           <a
             href={source}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            className="mt-4 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             <ExternalLink className="h-4 w-4 shrink-0" aria-hidden="true" />
-            View on Apple Developer
+            View the current version on Apple Developer
+            <span className="sr-only"> (opens in new tab)</span>
           </a>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* Related topics */}
       {relatedTopics.length > 0 && (
@@ -60,7 +99,7 @@ export default function TopicSidebar({
           <p className="text-[13px] uppercase tracking-wider text-muted-foreground mb-3">
             Related topics
           </p>
-          <ul className="space-y-1.5">
+          <ul className="space-y-1.5 list-none p-0">
             {relatedTopics.map((topic) => (
               <li key={topic.slug}>
                 <a

--- a/website/components/TopicToc.tsx
+++ b/website/components/TopicToc.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { List } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { TocEntry } from "@/lib/markdown";
+import { cn } from "@/lib/utils";
+
+function TocLinks({
+  items,
+  activeId,
+}: {
+  items: TocEntry[];
+  activeId: string;
+}) {
+  return (
+    <ul className="space-y-1 list-none p-0">
+      {items.map((item) => (
+        <li key={item.id}>
+          <a
+            href={`#${item.id}`}
+            aria-current={activeId === item.id ? "true" : undefined}
+            className={cn(
+              "block border-l-2 py-1 pl-3 text-sm transition-colors",
+              activeId === item.id
+                ? "border-foreground text-foreground"
+                : "border-border/60 text-muted-foreground hover:text-foreground hover:border-muted-foreground",
+            )}
+          >
+            {item.text}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * "On this page" navigation for a topic's h2 sections.
+ * - `variant="sidebar"`: always-visible list with a scrollspy highlight.
+ * - `variant="collapsible"`: <details> disclosure for compact layouts where
+ *   the sidebar sits below the article.
+ */
+export default function TopicToc({
+  items,
+  variant = "sidebar",
+  className,
+}: {
+  items: TocEntry[];
+  variant?: "sidebar" | "collapsible";
+  className?: string;
+}) {
+  const [activeId, setActiveId] = useState("");
+
+  useEffect(() => {
+    if (variant !== "sidebar" || items.length === 0) return;
+    const headings = items
+      .map((i) => document.getElementById(i.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (headings.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Highlight the last heading that has scrolled above the trigger line
+        const visible = entries.filter((e) => e.isIntersecting);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: "-80px 0px -70% 0px", threshold: 0 },
+    );
+    for (const el of headings) observer.observe(el);
+    return () => observer.disconnect();
+  }, [items, variant]);
+
+  if (items.length < 2) return null;
+
+  if (variant === "collapsible") {
+    return (
+      <details className={cn("group rounded-xl glass", className)}>
+        <summary className="flex cursor-pointer list-none items-center gap-2 px-4 py-3 text-sm font-medium text-foreground [&::-webkit-details-marker]:hidden">
+          <List className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          On this page
+          <span className="ml-auto text-xs text-muted-foreground group-open:hidden">
+            {items.length} sections
+          </span>
+        </summary>
+        <div className="px-4 pb-4">
+          <TocLinks items={items} activeId="" />
+        </div>
+      </details>
+    );
+  }
+
+  return (
+    <nav aria-label="On this page" className={className}>
+      <p className="text-[13px] uppercase tracking-wider text-muted-foreground mb-3">
+        On this page
+      </p>
+      <TocLinks items={items} activeId={activeId} />
+    </nav>
+  );
+}

--- a/website/components/TopicsExplorer.tsx
+++ b/website/components/TopicsExplorer.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { FileText, Search, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ExplorerTopic {
+  slug: string;
+  title: string;
+}
+
+export interface ExplorerSkillGroup {
+  skillDisplayName: string;
+  topics: ExplorerTopic[];
+}
+
+export interface ExplorerCategory {
+  categoryName: string;
+  anchor: string;
+  skills: ExplorerSkillGroup[];
+}
+
+function topicMatches(topic: ExplorerTopic, skillName: string, q: string) {
+  return (
+    topic.title.toLowerCase().includes(q) || skillName.toLowerCase().includes(q)
+  );
+}
+
+export default function TopicsExplorer({
+  categories,
+  totalTopics,
+}: {
+  categories: ExplorerCategory[];
+  totalTopics: number;
+}) {
+  const [query, setQuery] = useState("");
+
+  // Restore a shared/bookmarked search (?q=...) after mount; reading
+  // window.location here avoids a useSearchParams Suspense boundary on an
+  // otherwise fully static page.
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get("q");
+    if (q) setQuery(q);
+  }, []);
+
+  // Keep the URL restorable without adding history entries per keystroke.
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    if (query) {
+      url.searchParams.set("q", query);
+    } else {
+      url.searchParams.delete("q");
+    }
+    window.history.replaceState(null, "", url);
+  }, [query]);
+
+  const q = query.trim().toLowerCase();
+
+  const filtered = useMemo(() => {
+    if (!q) return categories;
+    return categories
+      .map((cat) => {
+        const categoryHit = cat.categoryName.toLowerCase().includes(q);
+        const skills = cat.skills
+          .map((skill) => ({
+            ...skill,
+            topics:
+              categoryHit || skill.skillDisplayName.toLowerCase().includes(q)
+                ? skill.topics
+                : skill.topics.filter((t) =>
+                    topicMatches(t, skill.skillDisplayName, q),
+                  ),
+          }))
+          .filter((skill) => skill.topics.length > 0);
+        return { ...cat, skills };
+      })
+      .filter((cat) => cat.skills.length > 0);
+  }, [categories, q]);
+
+  const matchCount = q
+    ? filtered.reduce(
+        (sum, cat) =>
+          sum + cat.skills.reduce((s, sk) => s + sk.topics.length, 0),
+        0,
+      )
+    : totalTopics;
+
+  return (
+    <div>
+      {/* Search */}
+      <div className="mx-auto max-w-xl mb-4">
+        <div className="relative">
+          <Search
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
+            aria-hidden="true"
+          />
+          <input
+            type="search"
+            placeholder="Search topics — try “tab bars”, “dark mode”, “Apple Pay”…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="w-full rounded-lg border bg-card/50 pl-9 pr-9 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
+            aria-label="Search HIG topics"
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 rounded-full text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Clear search"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+        <p
+          className="mt-2 text-center text-sm text-muted-foreground"
+          aria-live="polite"
+        >
+          {q
+            ? `${matchCount} of ${totalTopics} topics match “${query.trim()}”`
+            : `${totalTopics} topics across ${categories.length} categories`}
+        </p>
+      </div>
+
+      {/* Category jump nav — hidden while searching, when sections may be gone */}
+      {!q && (
+        <nav
+          aria-label="Topic categories"
+          className="mb-10 flex flex-wrap items-center justify-center gap-2"
+        >
+          {categories.map((cat) => {
+            const count = cat.skills.reduce((s, sk) => s + sk.topics.length, 0);
+            return (
+              <a
+                key={cat.anchor}
+                href={`#${cat.anchor}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-muted/40 px-3.5 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-colors"
+              >
+                {cat.categoryName}
+                <span className="text-xs text-muted-foreground/60 tabular-nums">
+                  {count}
+                </span>
+              </a>
+            );
+          })}
+        </nav>
+      )}
+
+      {/* Empty state */}
+      {q && filtered.length === 0 && (
+        <div className="rounded-xl glass px-6 py-12 text-center">
+          <p className="text-foreground font-medium mb-1">
+            No topics match “{query.trim()}”
+          </p>
+          <p className="text-sm text-muted-foreground mb-5 max-w-md mx-auto">
+            Try a component name (“buttons”), a platform (“watchOS”), or a
+            design concept (“typography”). Every topic here comes from Apple’s
+            Human Interface Guidelines.
+          </p>
+          <button
+            type="button"
+            onClick={() => setQuery("")}
+            className="text-sm underline underline-offset-4 text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Clear search
+          </button>
+        </div>
+      )}
+
+      {/* Category sections */}
+      <div className="space-y-8 pb-16">
+        {filtered.map((cat) => {
+          const showSkillHeadings =
+            cat.skills.length > 1 ||
+            cat.skills.some((sk) => sk.skillDisplayName !== cat.categoryName);
+          return (
+            <section
+              key={cat.categoryName}
+              id={q ? undefined : cat.anchor}
+              aria-labelledby={`cat-${cat.anchor}`}
+              className="rounded-xl glass p-6 sm:p-8 scroll-mt-24"
+            >
+              <h2
+                id={`cat-${cat.anchor}`}
+                className="text-2xl font-semibold tracking-tight mb-5"
+              >
+                {cat.categoryName}
+              </h2>
+              <div className={cn(showSkillHeadings ? "space-y-6" : "")}>
+                {cat.skills.map((skill) => (
+                  <div key={skill.skillDisplayName}>
+                    {showSkillHeadings && (
+                      <h3 className="text-sm uppercase tracking-wider text-muted-foreground mb-3">
+                        {skill.skillDisplayName}
+                      </h3>
+                    )}
+                    <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-1 list-none p-0">
+                      {skill.topics.map((topic) => (
+                        <li key={topic.slug}>
+                          <a
+                            href={`/topics/${topic.slug}`}
+                            className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1.5"
+                          >
+                            <FileText
+                              className="h-3.5 w-3.5 shrink-0 opacity-50"
+                              aria-hidden="true"
+                            />
+                            {topic.title}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/website/lib/markdown.ts
+++ b/website/lib/markdown.ts
@@ -56,6 +56,28 @@ function rehypeRewriteHigLinks() {
   };
 }
 
+export interface TocEntry {
+  id: string;
+  text: string;
+}
+
+/**
+ * Pulls the h2 outline out of rendered topic HTML for the "On this page"
+ * navigation. Headings carry ids from rehype-slug and wrap their text in an
+ * anchor (rehype-autolink-headings behavior: "wrap").
+ */
+export function extractH2Outline(html: string): TocEntry[] {
+  const entries: TocEntry[] = [];
+  const re = /<h2 id="([^"]+)"[^>]*>([\s\S]*?)<\/h2>/g;
+  let m = re.exec(html);
+  while (m !== null) {
+    const text = m[2].replace(/<[^>]+>/g, "").trim();
+    if (text) entries.push({ id: m[1], text });
+    m = re.exec(html);
+  }
+  return entries;
+}
+
 export async function renderMarkdown(content: string): Promise<string> {
   const result = await unified()
     .use(remarkParse)

--- a/website/lib/topics.ts
+++ b/website/lib/topics.ts
@@ -16,6 +16,51 @@ export interface TopicMeta {
 export interface TopicData extends TopicMeta {
   content: string;
   relatedTopics: TopicMeta[];
+  prevTopic: TopicMeta | null;
+  nextTopic: TopicMeta | null;
+}
+
+const ATTRIBUTION_MARKER = "<!-- hig-doctor:attribution -->";
+
+/**
+ * Splits the legal-hardening attribution block off the topic body so the page
+ * can present the same facts (source, snapshot date, Apple copyright) as
+ * structured metadata instead of a lead blockquote. The raw markdown endpoint
+ * keeps serving the untouched content — this only affects HTML presentation.
+ */
+export function splitAttribution(content: string): {
+  body: string;
+  snapshotDate: string | null;
+} {
+  const markerIdx = content.indexOf(ATTRIBUTION_MARKER);
+  if (markerIdx === -1) return { body: content, snapshotDate: null };
+
+  const lines = content.split("\n");
+  const out: string[] = [];
+  let snapshotDate: string | null = null;
+  let inBlock = false;
+  let blockDone = false;
+
+  for (const line of lines) {
+    if (!blockDone && line.trim() === ATTRIBUTION_MARKER) {
+      inBlock = true;
+      continue;
+    }
+    if (inBlock) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith(">") || trimmed === "") {
+        const m = trimmed.match(/snapshot (\d{4}-\d{2}-\d{2})/i);
+        if (m) snapshotDate = m[1];
+        if (trimmed === "" && out.length > 0) out.push(line);
+        continue;
+      }
+      inBlock = false;
+      blockDone = true;
+    }
+    out.push(line);
+  }
+
+  return { body: out.join("\n").replace(/^\n+/, ""), snapshotDate };
 }
 
 const SKILLS_DIR = path.join(process.cwd(), "..", "skills");
@@ -90,7 +135,9 @@ function extractExcerpt(content: string, maxLen = 155): string {
       trimmed.startsWith("#") ||
       trimmed.startsWith("|") ||
       trimmed.startsWith("---") ||
-      trimmed.startsWith("```")
+      trimmed.startsWith("```") ||
+      trimmed.startsWith(">") ||
+      trimmed.startsWith("<!--")
     )
       continue;
     // Strip markdown formatting: bold, italic, links, inline code
@@ -154,7 +201,9 @@ export function getAllTopicMetas(): TopicMeta[] {
           slug,
           title: title || slug.replace(/-/g, " "),
           source,
-          excerpt: extractExcerpt(content),
+          // Excerpt from the body only — the attribution block would otherwise
+          // become the meta description of every topic page.
+          excerpt: extractExcerpt(splitAttribution(content).body),
           skillName: skill.name,
           skillDisplayName: info?.skillDisplayName ?? skill.displayName,
           categoryName: info?.categoryName ?? cat.name,
@@ -203,9 +252,18 @@ export function getTopicBySlug(slug: string): TopicData | null {
   related.push(...sameSkill, ...sameCategory);
   const relatedTopics = related.slice(0, 8);
 
+  // Sequential navigation within the skill (metas are in stable file order)
+  const skillTopics = metas.filter((m) => m.skillName === meta.skillName);
+  const idx = skillTopics.findIndex((m) => m.slug === slug);
+  const prevTopic = idx > 0 ? skillTopics[idx - 1] : null;
+  const nextTopic =
+    idx >= 0 && idx < skillTopics.length - 1 ? skillTopics[idx + 1] : null;
+
   return {
     ...meta,
     content,
     relatedTopics,
+    prevTopic,
+    nextTopic,
   };
 }

--- a/website/lib/utils.ts
+++ b/website/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/** URL-safe anchor for a category or section name, shared by /topics and topic sidebars. */
+export function anchorFor(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}


### PR DESCRIPTION
## What

Website-only redesign of the HIG reference browsing experience. No skill content, CLI, or MCP code changes.

- **/topics**: instant search with live match count, shareable `?q=` state, category jump pills with counts, a real no-results state, glass category panels, de-duplicated category/skill headings
- **/topics/[slug]**: "On this page" outline (sticky sidebar + scrollspy on desktop, disclosure on compact widths), previous/next within each skill, **Copy as Markdown / View as Markdown** actions surfacing the existing `/raw/[slug]` endpoint, attribution presented as sidebar metadata ("About this reference": skill, HIG snapshot Feb 2025, Apple link) + article small print instead of a lead blockquote — markdown files and `/raw/` output untouched
- **Header**: Topics added to home nav, route-aware active states (`aria-current="page"`), mobile nav ARIA corrected
- **/mcp**: copy buttons on install blocks, clearer eyebrow, cross-link to /topics
- **Fixes**: topic meta descriptions no longer emit the literal `<!-- hig-doctor:attribution -->` comment (all 156 pages); FAQ counts derive from skills-data (was stale "100+"); doubled search-cancel control hidden; `scroll-margin-top` keeps anchored headings clear of the fixed header

## Verification

- `tsc --noEmit` clean · `biome check` clean · website `bun test` 5/5 · root `npm test` 7/7 · `next build` generates all 322 static pages
- Browser-verified at 1440/1280/768/375: search + deep-linked filters, no-results recovery, mobile TOC disclosure, hamburger menu active states, TOC anchor offset (88px vs 64px header), SSR HTML still contains all 156 topic links for SEO

🤖 Generated with [Claude Code](https://claude.com/claude-code)