### PR TITLE
Publish HIG Doctor core under the Raintree npm scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Agent-native Apple Human Interface Guidelines: a structured skills corpus, MCP s
 - **Skills corpus** — 14 skills and 156 reference topics covering the complete HIG (foundations, components, patterns, inputs, platforms, technologies). Snapshot dated 2025-02-02; canonical content remains at [developer.apple.com/design/human-interface-guidelines](https://developer.apple.com/design/human-interface-guidelines/).
 - **MCP server** ([`hig-mcp`](https://www.npmjs.com/package/hig-mcp)) — six tools for Claude Desktop, Cursor, Windsurf, and Claude Code: `hig_list_skills`, `hig_lookup`, `hig_search` (BM25 over every topic), `hig_audit`, `hig_audit_file`, and `hig_explain_finding`. Runs over stdio or streamable HTTP.
 - **Audit CLI** ([`hig-doctor`](https://www.npmjs.com/package/hig-doctor)) — a **431-rule** compliance scanner across 15 frameworks. A regex base tier plus a TypeScript-compiler JSX tier and a Swift structural tier; every finding is tagged with the engine that produced it. Config files, inline suppressions, baselines, SARIF output, and `--fix` autofixes.
-- **Engine** ([`@hig-doctor/core`](https://www.npmjs.com/package/@hig-doctor/core)) — the rule engine, embeddable in your own tooling.
+- **Engine** ([`@raintree-technology/hig-doctor-core`](https://www.npmjs.com/package/@raintree-technology/hig-doctor-core)) — the rule engine, embeddable in your own tooling.
 
 Content is © Apple Inc.; this repository provides organization, cross-referencing, and detection rules for AI agent use. MIT-licensed for structure and tooling.
 
@@ -283,7 +283,7 @@ hig-doctor/
 ├── brand/                                # Canonical logo, app icon, and usage guidance
 ├── skills/                                # 14 Agent Skills (SKILL.md + references/)
 ├── packages/
-│   ├── core/                              # @hig-doctor/core rule engine (scan → detect → categorize → report)
+│   ├── core/                              # @raintree-technology/hig-doctor-core rule engine (scan → detect → categorize → report)
 │   ├── cli/                               # hig-doctor audit CLI
 │   ├── mcp/                               # hig-mcp MCP server
 │   └── skill-validator/                   # Internal skill-structure validator (dev-only)

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/cli": {
       "name": "hig-doctor",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "bin": {
         "hig-doctor": "./dist/index.js",
       },
@@ -27,9 +27,12 @@
         "esbuild": "^0.25.0",
         "typescript": "^5.9.3",
       },
+      "optionalDependencies": {
+        "typescript": "^5.9.3",
+      },
     },
     "packages/core": {
-      "name": "@hig-doctor/core",
+      "name": "@raintree-technology/hig-doctor-core",
       "version": "0.1.0",
       "devDependencies": {
         "@types/bun": "^1.3.3",
@@ -37,10 +40,13 @@
         "esbuild": "^0.25.0",
         "typescript": "^5.9.3",
       },
+      "optionalDependencies": {
+        "typescript": "^5.9.3",
+      },
     },
     "packages/mcp": {
       "name": "hig-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "hig-mcp": "./dist/index.js",
       },
@@ -49,6 +55,9 @@
         "@types/bun": "^1.3.3",
         "@types/node": "^20",
         "esbuild": "^0.25.0",
+        "typescript": "^5.9.3",
+      },
+      "optionalDependencies": {
         "typescript": "^5.9.3",
       },
     },
@@ -191,8 +200,6 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "@hig-doctor/core": ["@hig-doctor/core@workspace:packages/core"],
-
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
@@ -330,6 +337,8 @@
     "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@raintree-technology/hig-doctor-core": ["@raintree-technology/hig-doctor-core@workspace:packages/core"],
 
     "@remotion/bundler": ["@remotion/bundler@4.0.484", "", { "dependencies": { "@remotion/media-parser": "4.0.484", "@remotion/studio": "4.0.484", "@remotion/studio-shared": "4.0.484", "@remotion/timeline-utils": "4.0.484", "@rspack/core": "1.7.11", "@rspack/plugin-react-refresh": "1.6.1", "css-loader": "7.1.4", "esbuild": "0.28.1", "react-refresh": "0.18.0", "remotion": "4.0.484", "style-loader": "4.0.0", "webpack": "5.105.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-ZGTWt7hX9qjeeqRxZyxcgpgEbKgDjqP23RaOFP+hLcvDC8In54BZML68Vgss50BP2Gt2M5bcSLRLZtIDWo1dNw=="],
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -34,7 +34,7 @@ Engine, distribution, and workflow overhaul.
 
 ### Changed
 
-- Now built on the extracted `@hig-doctor/core` engine; the package moved to
+- Now built on the extracted `@raintree-technology/hig-doctor-core` engine; the package moved to
   `packages/cli` in the restructured monorepo.
 - `--json` schema bumped to 2: adds `toolVersion`, `higSnapshot`, `config`,
   `baseline`, and a per-concern `concerns` array with fix/suggestion/HIG fields.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "audit": "bun src/cli.ts",
     "audit:export": "bun src/cli.ts . --export",
     "audit:stdout": "bun src/cli.ts . --stdout",
-    "build": "esbuild src/cli.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/index.js --alias:@hig-doctor/core=../core/src/index.ts --external:typescript --banner:js=\"#!/usr/bin/env node\"",
+    "build": "esbuild src/cli.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/index.js --alias:@raintree-technology/hig-doctor-core=../core/src/index.ts --external:typescript --banner:js=\"#!/usr/bin/env node\"",
     "prepublishOnly": "bun run build",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,8 +12,8 @@ import {
   applyFixes,
   BASELINE_FILENAME,
   HIG_SNAPSHOT_DATE,
-} from "@hig-doctor/core";
-import type { Severity, PatternMatch, ScannedFile } from "@hig-doctor/core";
+} from "@raintree-technology/hig-doctor-core";
+import type { Severity, PatternMatch, ScannedFile } from "@raintree-technology/hig-doctor-core";
 import pkg from "../package.json";
 import { writeFile as fsWriteFile } from "node:fs/promises";
 import { writeFile } from "node:fs/promises";

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,7 +11,7 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@hig-doctor/core": ["../core/src/index.ts"]
+      "@raintree-technology/hig-doctor-core": ["../core/src/index.ts"]
     }
   },
   "include": ["src", "../core/src"]

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `@hig-doctor/core` are documented here.
+All notable changes to `@raintree-technology/hig-doctor-core` are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,12 +2,12 @@
   <img src="https://raw.githubusercontent.com/raintree-technology/hig-doctor/main/brand/hig-doctor-mark.svg" alt="HIG Doctor" width="72" height="72" />
 </p>
 
-# @hig-doctor/core
+# @raintree-technology/hig-doctor-core
 
 The rule engine behind [HIG Doctor](https://github.com/raintree-technology/hig-doctor): framework detection, the Apple HIG rule catalog, tiered analysis (regex → Swift structural → TypeScript-compiler JSX), and the audit pipeline. The [`hig-doctor`](../cli) CLI and [`hig-mcp`](../mcp) server are thin wrappers over this package; embed it directly to run audits from your own tooling.
 
 ```ts
-import { audit, analyzeFile, ruleCatalog, toSarif } from "@hig-doctor/core";
+import { audit, analyzeFile, ruleCatalog, toSarif } from "@raintree-technology/hig-doctor-core";
 
 // Whole-directory audit (honors hig-doctor.config.json, baselines, suppressions)
 const result = await audit("./my-app");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hig-doctor/core",
+  "name": "@raintree-technology/hig-doctor-core",
   "version": "0.1.0",
   "description": "Rule engine powering HIG Doctor: framework detection, Apple HIG pattern rules, and the audit pipeline.",
   "type": "module",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-// @hig-doctor/core — public API surface.
+// @raintree-technology/hig-doctor-core — public API surface.
 // The CLI, MCP server, and website audit demo all consume the engine through
 // this module; keep additions here deliberate since they become npm API.
 export {

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The published package now bundles the skills corpus (`dist/skills`), so
   `npx hig-mcp` works with no clone; `HIG_SKILLS_DIR` becomes an optional override.
-- Now built on the extracted `@hig-doctor/core` engine.
+- Now built on the extracted `@raintree-technology/hig-doctor-core` engine.
 
 ## [0.1.0] - 2026-05-28
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "start": "bun src/index.ts",
-    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/index.js --alias:@hig-doctor/core=../core/src/index.ts --external:typescript --banner:js=\"#!/usr/bin/env node\" && bun run bundle:skills",
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/index.js --alias:@raintree-technology/hig-doctor-core=../core/src/index.ts --external:typescript --banner:js=\"#!/usr/bin/env node\" && bun run bundle:skills",
     "bundle:skills": "rm -rf dist/skills && cp -R ../../skills dist/skills",
     "prepublishOnly": "bun run build",
     "test": "bun test",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -38,7 +38,7 @@ import {
   HIG_SNAPSHOT_DATE,
   type PatternMatch,
   type Severity,
-} from "@hig-doctor/core";
+} from "@raintree-technology/hig-doctor-core";
 import { SearchIndex } from "./search";
 import pkg from "../package.json";
 

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -11,7 +11,7 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@hig-doctor/core": ["../core/src/index.ts"]
+      "@raintree-technology/hig-doctor-core": ["../core/src/index.ts"]
     }
   },
   "include": ["src", "../core/src"]


### PR DESCRIPTION
## Summary
- use the existing `@raintree-technology` npm scope for the core package
- update source imports, build aliases, docs, and the workspace lockfile
- avoid creating a separate npm organization for HIG Doctor

## Verification
- `bun run validate:full`
- core package dry-run passed
- staged secret scan passed
